### PR TITLE
Set `$old_things` to an array if unset

### DIFF
--- a/inc/cpt/cmb.php
+++ b/inc/cpt/cmb.php
@@ -196,7 +196,7 @@ function get_old_meta( $meta_key, $revisions, $post_id ) {
  * @since  0.1.1
  */
 function clean_old_data( $current_thing, $old_things ) {
-	$old_things = array_filter( $old_things );
+	$old_things = is_array( $old_things ) ? array_filter( $old_things ) : [];
 	$index      = array_search( $current_thing, $old_things );
 	if ( false !== $index ) {
 		unset( $old_things[ $index ] );

--- a/plugin.php
+++ b/plugin.php
@@ -6,7 +6,7 @@
  * Author: Chris Reynolds
  * Author URI: https://chrisreynolds.io
  * License: GPLv3
- * Version: 0.3.3
+ * Version: 0.3.4
  *
  * @package AddressBook
  */


### PR DESCRIPTION
This fixes an issue in PHP 8.4 where a null value causes `array_filter()` to fatal error if passed.